### PR TITLE
词法分析测试用例:

### DIFF
--- a/lexer_v2/lexer_v2_test.go
+++ b/lexer_v2/lexer_v2_test.go
@@ -313,7 +313,7 @@ func runLexerTest(t *testing.T, tests []lexerTestCase) {
 	t.Helper()
 	for _, tt := range tests {
 		l := New(tt.input)
-		checkParserErrors(t, l)
+		checkLexerErrors(t, l)
 
 		for i, expTok := range tt.expectedTokens {
 			tok := l.NextToken()
@@ -325,7 +325,7 @@ func runLexerTest(t *testing.T, tests []lexerTestCase) {
 	}
 }
 
-func checkParserErrors(t *testing.T, l *Lexer) {
+func checkLexerErrors(t *testing.T, l *Lexer) {
 	errTokens := l.Errors()
 	if len(errTokens) == 0 {
 		return


### PR DESCRIPTION
1. 修改辅助函数名称