### PR TITLE
Modify the read_line reading logic

### DIFF
--- a/src/fs/woc_file.rs
+++ b/src/fs/woc_file.rs
@@ -1,56 +1,81 @@
+use std::collections::HashMap;
 use std::fs::File;
-use std::io::{self, BufRead, BufReader};
+use std::io::{BufRead, BufReader};
 use std::path::Path;
 
 pub struct WocFile {
     path: String,
     name: Option<String>,
-    size: Option<u64>,
-    reader: Option<BufReader<File>>,
+    // The mapping between file line numbers and code lines
+    line_num_and_code_map: HashMap<usize, String>,
     current_line: usize,
 }
 
 impl WocFile {
     // Create a new WocFile object by only recording the path
     pub fn new(path: String) -> Self {
-        Self {
+        let mut wf = Self {
             path,
             name: None,
-            size: None,
-            reader: None,
-            current_line: 0,
-        }
-    }
+            line_num_and_code_map: HashMap::new(),
+            current_line: 1,
+        };
 
-    // Initialize the file reader and other fields if not already done
-    fn initialize(&mut self) -> io::Result<()> {
-        if self.reader.is_none() {
-            let path = Path::new(&self.path);
-            let file = File::open(path)?;
-            self.size = Some(file.metadata()?.len());
-            self.name = Some(path.file_name().unwrap().to_string_lossy().to_string());
-            self.reader = Some(BufReader::new(file));
+        // Get file object
+        let path = Path::new(&wf.path);
+        wf.name = Some(path.file_name().unwrap().to_string_lossy().to_string());
+        let file = match File::open(path) {
+            Ok(f) => f,
+            Err(_) => panic!("Failed to open file"),
+        };
+
+        // Get file reader
+        let mut reader = BufReader::new(file);
+
+        // Read file line by line and store the line number and code line
+        let mut line = String::new();
+        let mut line_number = 0;
+        loop {
+            line.clear();
+            match reader.read_line(&mut line) {
+                Ok(0) => {
+                    break;
+                }
+                Ok(_) => {
+                    line_number += 1;
+                    wf.line_num_and_code_map
+                        .insert(line_number, line.trim().to_string());
+                }
+                Err(_) => {
+                    break;
+                }
+            }
         }
-        Ok(())
+
+        wf
     }
 
     // Read a new line from the file and return the current line number and line content
-    pub fn read_line(&mut self) -> io::Result<(usize, String)> {
-        self.initialize()?;
-
-        let reader = self.reader.as_mut().unwrap();
-        let mut line = String::new();
-        let bytes_read = reader.read_line(&mut line)?;
-        if bytes_read == 0 {
-            // End of file reached
-            return Err(io::Error::new(
-                io::ErrorKind::UnexpectedEof,
-                "End of file reached",
-            ));
+    pub fn read_line(&mut self) -> Option<(usize, String)> {
+        // It's means the file is empty
+        if self.line_num_and_code_map.len() <= 0
+            || self.current_line > self.line_num_and_code_map.len()
+        {
+            return None;
         }
 
+        // Get the current line content
+        let line = self
+            .line_num_and_code_map
+            .get(&self.current_line)
+            .unwrap()
+            .clone();
+
+        // Move the current line number to the next line
+        let line_num = self.current_line;
         self.current_line += 1;
-        Ok((self.current_line, line))
+
+        Some((line_num, line))
     }
 
     // Get the file path
@@ -61,10 +86,5 @@ impl WocFile {
     // Get the file name
     pub fn get_name(&self) -> Option<&String> {
         self.name.as_ref()
-    }
-
-    // Get the file size
-    pub fn get_size(&self) -> Option<u64> {
-        self.size
     }
 }

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -69,8 +69,8 @@ impl Lexer {
 
         loop {
             let (line, code) = match l.woc_file.read_line() {
-                Ok((line, code)) => (line, code),
-                Err(_) => break,
+                Some((line, code)) => (line, code),
+                None => break,
             };
 
             l.cur_line.set(line);

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -788,7 +788,7 @@ impl Lexer {
     fn move_start_index_to_next_non_blank_char(&self) {
         let mut index = self.start_index.get();
 
-        // Move index to next non blank char.
+        // Move index to next non-blank char.
         while index < self.cur_code_chars.len() && self.cur_code_chars[index].is_whitespace() {
             index += 1;
         }

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -20,11 +20,7 @@ pub struct Lexer {
     cur_line: Cell<usize>,
 
     // The number of columns of code currently parsed
-<<<<<<< HEAD
     cur_tok_num: Cell<usize>,
-=======
-    cur_column: Cell<usize>,
->>>>>>> 0c7a9c50cacad75c9cf27f4e7cb4f18a9d575fdf
 
     // The code that is currently being parsed.
     cur_code_chars: Vec<char>,
@@ -65,11 +61,7 @@ impl Lexer {
             start_index: Cell::new(0),
             cur_index: Cell::new(0),
             cur_line: Cell::new(0),
-<<<<<<< HEAD
             cur_tok_num: Cell::new(1),
-=======
-            cur_column: Cell::new(1),
->>>>>>> 0c7a9c50cacad75c9cf27f4e7cb4f18a9d575fdf
             cur_code_chars: Vec::new(),
             tokens: RefCell::new(Vec::new()),
             cur_state: Cell::new(State::StartState),
@@ -91,13 +83,8 @@ impl Lexer {
             TokenType::Eof,
             "",
             l.woc_file.get_path(),
-<<<<<<< HEAD
             l.cur_line.get() + 1,
             l.cur_tok_num.get(),
-=======
-            l.cur_line.get(),
-            0,
->>>>>>> 0c7a9c50cacad75c9cf27f4e7cb4f18a9d575fdf
         )));
 
         l
@@ -107,11 +94,7 @@ impl Lexer {
         self.start_index.set(0);
         self.cur_index.set(0);
         self.cur_state.set(State::StartState);
-<<<<<<< HEAD
         self.cur_tok_num.set(1);
-=======
-        self.cur_column.set(1);
->>>>>>> 0c7a9c50cacad75c9cf27f4e7cb4f18a9d575fdf
     }
 
     /// Creates a new [`LexerIter`].
@@ -786,11 +769,7 @@ impl Lexer {
             &literal,
             self.woc_file.get_path(),
             self.cur_line.get(),
-<<<<<<< HEAD
             self.cur_tok_num.get(),
-=======
-            0,
->>>>>>> 0c7a9c50cacad75c9cf27f4e7cb4f18a9d575fdf
         )));
 
         // Update the column number.

--- a/src/token/token.rs
+++ b/src/token/token.rs
@@ -54,13 +54,8 @@ impl Token {
         self.file_row_number
     }
 
-<<<<<<< HEAD
     pub fn token_number_in_line(&self) -> usize {
         self.token_number_in_line
-=======
-    pub fn column_number_in_line(&self) -> usize {
-        self.column_number_in_line
->>>>>>> 0c7a9c50cacad75c9cf27f4e7cb4f18a9d575fdf
     }
 
     pub fn precedence(&self) -> u32 {


### PR DESCRIPTION
Add the mapping between storage line numbers and code lines in wocFile for syntax parsing and source code path tracking, and modify the read_line reading logic.